### PR TITLE
Pytango optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ pydantic = "^1.10.5"
 fastapi = "^0.92.0"
 pillow = "^9.4.0"
 uvicorn = "^0.20.0"
-pytango = "^9.3.0"
+pytango = { version = "^9.3.0", optional=true}
 jinja2 = "^3.1.2"
 websockets = "^10.4"
 

--- a/video_streamer/core/camera.py
+++ b/video_streamer/core/camera.py
@@ -5,6 +5,7 @@ import sys
 import os
 import io
 import multiprocessing
+import multiprocessing.queues
 
 from typing import Union, IO, Tuple
 

--- a/video_streamer/core/camera.py
+++ b/video_streamer/core/camera.py
@@ -9,7 +9,11 @@ import multiprocessing
 from typing import Union, IO, Tuple
 
 from PIL import Image
-from PyTango import DeviceProxy
+
+try:
+    from PyTango import DeviceProxy
+except ImportError:
+    logging.warning("PyTango not available.")
 
 
 class Camera:


### PR DESCRIPTION
@marcus-oscarsson, small suggestions, feel free to reject.

The reason I made pytango as optional is that this way i can run mxcube with mockups in a mac machine (pytango is not yet easily available in mac)