### PR TITLE
Added publish to redis-server functionality

### DIFF
--- a/video_streamer/core/config.py
+++ b/video_streamer/core/config.py
@@ -12,6 +12,8 @@ class SourceConfiguration(BaseModel):
     format: str = Field("MPEG1", description="Output format MPEG1 or MJPEG")
     hash: str = Field("", description="Server url postfix/trail")
     size: Tuple[int, int] = Field((0, 0), description="Image size")
+    redis: str = Field(None, description="redis host and port (format host:port)")
+    redis_channel: str = Field("video-streamer", description="redis-channel to publish stream")
 
 
 class ServerConfiguration(BaseModel):

--- a/video_streamer/core/streamer.py
+++ b/video_streamer/core/streamer.py
@@ -29,11 +29,11 @@ class MJPEGStreamer(Streamer):
         self._expt = 0.05
 
         if self._config.input_uri == "test":
-            self._camera = TestCamera("TANGO_URI", self._expt, False)
+            self._camera = TestCamera("TANGO_URI", self._expt, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("http"):
-            self._camera = MJPEGCamera(self._config.input_uri, self._expt, False)
+            self._camera = MJPEGCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
         else:
-            self._camera = LimaCamera(self._config.input_uri, self._expt, False)
+            self._camera = LimaCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
 
     def start(self) -> None:
         _q = multiprocessing.Queue(1)
@@ -130,11 +130,11 @@ class FFMPGStreamer(Streamer):
 
     def start(self) -> None:
         if self._config.input_uri == "test":
-            camera = TestCamera("TANGO_URI", 0.02, False)
+            camera = TestCamera("TANGO_URI", 0.02, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("http"):
-            self._camera = MJPEGCamera(self._config.input_uri, self._expt, False)
+            self._camera = MJPEGCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
         else:
-            camera = LimaCamera(self._config.input_uri, 0.02, False)
+            camera = LimaCamera(self._config.input_uri, 0.02, False, self._config.redis, self._config.redis_channel)
 
         out_size = self._config.size if self._config.size[0] else camera.size
 


### PR DESCRIPTION
These changes include the functionality to publish the stream on a redis-server, simultaneously to running the websocket.

Currently works for the test camera and the lima camera and can be configured per input source by setting the corresponding flags. Default is to not use a redis-server.