### PR TITLE
Redis Camera

### DIFF
--- a/video_streamer/core/camera.py
+++ b/video_streamer/core/camera.py
@@ -269,7 +269,7 @@ class VideoTestCamera(Camera):
         size = frame_pil.size        
         frame_bytes = frame_pil.tobytes()
         self._write_data(bytearray(frame_bytes))
-
+        self._last_frame_number += 1
         if self._redis:
             frame_dict = {
                 "data": base64.b64encode(frame_bytes).decode('utf-8'),

--- a/video_streamer/core/config.py
+++ b/video_streamer/core/config.py
@@ -60,6 +60,11 @@ class SourceConfiguration(BaseModel):
         description="Redis-Channel to publish stream.",
         default="video-streamer",
     )
+    in_redis_channel: str = Field(
+        title="Input Redis Channel",
+        description= "Channel for RedisCamera to listen to",
+        default="CameraStream",
+    )
 
 
 class ServerConfiguration(BaseModel):

--- a/video_streamer/core/streamer.py
+++ b/video_streamer/core/streamer.py
@@ -4,7 +4,7 @@ import queue
 import time
 from typing import Tuple
 
-from video_streamer.core.camera import TestCamera, LimaCamera, MJPEGCamera, VideoTestCamera, Camera
+from video_streamer.core.camera import TestCamera, LimaCamera, MJPEGCamera, VideoTestCamera, Camera, RedisCamera
 from video_streamer.core.config import SourceConfiguration
 
 
@@ -29,6 +29,8 @@ class Streamer:
             return VideoTestCamera("TANGO_URI", self._expt, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("http"):
             return MJPEGCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
+        elif self._config.input_uri.startswith("redis"):
+            return RedisCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
         
         return LimaCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
 

--- a/video_streamer/core/streamer.py
+++ b/video_streamer/core/streamer.py
@@ -30,7 +30,7 @@ class Streamer:
         elif self._config.input_uri.startswith("http"):
             return MJPEGCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("redis"):
-            return RedisCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
+            return RedisCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel, self._config.in_redis_channel)
         
         return LimaCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
 

--- a/video_streamer/main.py
+++ b/video_streamer/main.py
@@ -116,6 +116,14 @@ def parse_args() -> None:
         default="video-streamer",
     )
 
+    opt_parser.add_argument(
+        "-irc",
+        "--in_redis_channel",
+        dest="in_redis_channel",
+        help="Channel for RedisCamera to listen to",
+        default="CameraStream",
+    )
+
     return opt_parser.parse_args()
 
 
@@ -142,6 +150,7 @@ def run() -> None:
                     "format": args.output_format,
                     "hash": args.hash,
                     "size": _size,
+                    "in_redis_channel": args.in_redis_channel,
                 }
             }
         }


### PR DESCRIPTION
This PR adds a `Redis` Camera to the video-streamer. It allows for images to be sent via redis channels, and converts them into the necessary stream. 
It adds an additional argument, the `--in-redis-channel`. This should be set when using this specific Camera, as it indicates the channel on the redis server, the images are sent on. Please be aware that this is different from the `--redis-channel`, which is for the outgoing redis pubsub channels and this camera doesn't need the `--redis` flag, as this is also only for outgoing pubsub channels. 

It extends the work that has been done on the `redis-camera` branch of this repository.

+ While at this, I realized that the `VideoTestCamera` never updates the `last_frame_number`, which was corrected in this PR as well