### PR TITLE
updates on documentation

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main 
 
 jobs:
   deploy:

--- a/docs/devs/contributing.md
+++ b/docs/devs/contributing.md
@@ -29,16 +29,12 @@ PRs should be made against the [main](https://github.com/mxcube/video-streamer/t
 ### Preparing a new commit
 1. Make sure that you are working with the latest changes from the main branch. From the root of the repository do:
 
-        ```bash
         git checkout main
         git pull --rebase main
-        ```
 
 1. Create a new branch. It is recommended to use a meaningful name, for instance: 
 
-        ```bash
         git checkout -b [initials]-[fix/feature]-[some name]
-        ```
     
     For the remainder of this page, we assume that your branch is called `mx-fix-documentation`.
 
@@ -46,11 +42,9 @@ PRs should be made against the [main](https://github.com/mxcube/video-streamer/t
 1. Test your changes and make sure, the code behaves as expected.
 1. Commit your changes and push the branch
 
-        ```bash
         git add .
         git commit -m "Add feature X"
         git push origin mx-fix-doumentation
-        ```
 
 ### Create a new PR on the Github webpage
 After committing and pushing your changes to the remote repository, the final step is to create a pull request (PR) for review and merging into the `main` branch. To do so, you can navigate to your branch on the github webpage and create a new pull request. Below you can find some general guidelines for your PR:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,12 +2,12 @@
 
 1. I use this application as part of the [web interface](http://github.com/mxcube/mxcubeweb) for MXCuBE; Unfortunately there is no stream output, what can I do?
 
-One possible issue could be a missing dependency for the `video-streamer`, especially `ffmpeg` is not correctly installed when the `video-streamer` is used as a dependency. You can try to fix this by simply installing `ffmpeg`.
+    One possible issue could be a missing dependency for the `video-streamer`, especially `ffmpeg` is not correctly installed when the `video-streamer` is used as a dependency. You can try to fix this by simply installing `ffmpeg`.
 
 1. What types of output streams are supported?
 
-Currently, *MJPEG* and *MPEG1* streams are supported, as well as the possibility to use a redis Pub/Sub channel as output. For more information about using the dual output stream with `Redis` you can read our [setup guide](./usage/setup.md#dual-streaming-seamlessly-serve-mjpeg-and-redis-pubsub-video-feeds).
+    Currently, *MJPEG* and *MPEG1* streams are supported, as well as the possibility to use a redis Pub/Sub channel as output. For more information about using the dual output stream with `Redis` you can read our [setup guide](./usage/setup.md#dual-streaming-seamlessly-serve-mjpeg-and-redis-pubsub-video-feeds).
 
 1. What types of input devices are supported?
 
-MXCuBE's Video Streamer supports a wide range of input devices, such as Tango (Lima) devices, MJPEG streams and Redis channels, as well as prerecorded videos and even single images for test streams. For more information on the supported devices and streams, you can read the [cameras guide](./usage/cameras.md)
+    MXCuBE's Video Streamer supports a wide range of input devices, such as Tango (Lima) devices, MJPEG streams and Redis channels, as well as prerecorded videos and even single images for test streams. For more information on the supported devices and streams, you can read the [cameras guide](./usage/cameras.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,29 +1,25 @@
 # Installation
 
-Start by cloning the repository to your local machine:
+1. Start by cloning the repository to your local machine:
 
-```bash
-git clone https://github.com/mxcube/video-streamer.git
-cd video-streamer
-```
+        git clone https://github.com/mxcube/video-streamer.git
+        cd video-streamer
 
-Optionally you can create a [conda](https://docs.conda.io/projects/conda/en/latest/index.html) environment like this:
+1. Optionally, you can create and activate a [conda](https://docs.conda.io/projects/conda/en/latest/index.html) environment like this:
 
-```bash
-conda env create -f conda-environment.yml
-```
+        conda env create -f conda-environment.yml
+        conda activate video-streamer
+    
+    If you skip this part, please make sure to have all necessary packages from `conda-environment.yml` installed.
 
-Install all dependencies necessary for the code to run either with pip:
+1. Install all dependencies necessary for the code to run; either with pip:
 
-```bash
-# for development
-pip install -e .
+        # for development
+        pip install -e .
 
-#for usage
-pip install .
-```
+        #for usage
+        pip install .
 
-or poetry:
-```bash
-poetry install
-```
+    or poetry:
+
+        poetry install

--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -63,7 +63,7 @@ There is a default test/demo UI to see the video stream on `http://localhost:[po
 
 There is the possibility to use a configuration file instead of command line arguments. All  command line arguments except debug are ignored if a config file is used. The configuration file also makes it possible to configure several sources while the command line only allows  configuration of a single source.
 
-The configuration file format is *JSON*. A test image is used when the input_uri is set to "test" (Same as `-uri` flag). The example below creates one *MPEG1* stream (on port 8000) and one *MJPEG* stream (on port 8001) from the test image.
+The configuration file format is *JSON*. A test image is used when the input_uri is set to `test` (Same as `-uri` flag). The example below creates one *MPEG1* stream (on port 8000) and one *MJPEG* stream (on port 8001) from the test image.
 
 Run: 
 


### PR DESCRIPTION
This PR includes the following changes on the documentation and documentation workflow (used by github action):
- Previously the workflow updated the documentation on every PR, this was removed, now it will only update it when pushing resp. merging a PR to `main`
- Some correction regarding indentation and enumeration