### PR TITLE
update MJPEGCamera

### DIFF
--- a/docs/usage/cameras.md
+++ b/docs/usage/cameras.md
@@ -36,6 +36,25 @@ The `MJPEGCamera` provides specialized support for *MJPEG* video streams. It is 
 
 > **Note**: Currently the `MJPEGCamera` is the only camera that does not support conversion to a `Redis` Pub/Sub channel (more about streaming on a [redis channel](setup.md#dual-streaming-seamlessly-serve-mjpeg-and-redis-pubsub-video-feeds))
 
+#### Authentication for MJPEG Streams
+
+Some MJPEG streams may require authentication to access. To support such scenarios, the `MJPEGCamera` class includes built-in authentication support. Currently, both `Basic` and `Digest` authentication methods are supported.
+
+Below is an example of how to use the video-streamer to access a stream requiring `Basic` authentication:
+
+```bash
+video-streamer -of MPEG1 -uri <stream_url> -auth Basic -user <username> -pass <password>
+```
+
+##### Explanation of the Parameters:
+- `-of`: Specifies the ouput format, here `MPEG1` is used.
+- `-uri`: The URL of the MJPEG stream.
+- `-auth`: Specifies the authentication method (`Basic` or `Digest`)
+- `-user`: The username for authentication
+- `-pass`: The password required for authentication
+
+Replace `<stream_url>`, `<username>` and `<password>` with the appropriate values for your stream. Ensure you handle credentials securely and avoid exposing them in public or shared scripts!
+
 ---
 
 ## RedisCamera
@@ -48,7 +67,7 @@ Instead of using a real camera, the `video-streamer` allows to use said `Redis` 
 To use the `RedisCamera`, one can use the following command:
 
 ```bash
-video-streamer -d -of MJPEG1 -uri redis://[host]:[port] -irc ExampleStream
+video-streamer -d -of MPEG1 -uri redis://[host]:[port] -irc ExampleStream
 ```
 
 where `host` and `port` are the respective host and port of the `Redis` server and `ExampleStream` would be the Pub/Sub channel to use for generating the stream. 

--- a/video_streamer/core/config.py
+++ b/video_streamer/core/config.py
@@ -17,12 +17,32 @@ else:
     from typing_extensions import Self
 
 __all__ = (
+    "AuthenticationConfiguration",
     "SourceConfiguration",
     "ServerConfiguration",
     "get_config_from_file",
     "get_config_from_dict",
+    "get_auth_config_from_dict",
 )
 
+class AuthenticationConfiguration(BaseModel):
+    """Authentication Configuration"""
+
+    type: Union[str, None] = Field(
+        title="Authentication Type",
+        description="Type of authentication, supported types are 'Basic', 'Digest', None",
+        default= None,
+    )
+
+    username: Union[bytes, str] = Field(
+        title="Username",
+        default="",
+    )
+
+    password: Union[bytes, str] = Field(
+        title="Password",
+        default="",
+    )
 
 class SourceConfiguration(BaseModel):
     """Source Configuration"""
@@ -65,7 +85,10 @@ class SourceConfiguration(BaseModel):
         description= "Channel for RedisCamera to listen to",
         default="CameraStream",
     )
-
+    auth_config: AuthenticationConfiguration = Field(
+        title="Authentication Configurations",
+        default=AuthenticationConfiguration(type=None),
+    )
 
 class ServerConfiguration(BaseModel):
     """Server Configuration"""
@@ -130,7 +153,7 @@ def get_config_from_file(fpath: Union[str, Path]) -> Union[ServerConfiguration, 
 
 
 def get_config_from_dict(
-    config_data: dict[str, Any],
+    config_data: Dict[str, Any],
 ) -> Union[ServerConfiguration, None]:
     """Get server configuration from dictionary.
 
@@ -142,5 +165,21 @@ def get_config_from_dict(
     """
     try:
         return ServerConfiguration.model_validate(config_data)
+    except ValidationError:
+        return None
+
+def get_auth_config_from_dict(
+    config_data: Dict[str, Any],
+) -> Union[AuthenticationConfiguration, None]:
+    """Get authentication configuration from dictionary.
+    
+    Args:
+        config_data (dict[str, Any]): Authentication Data.
+
+    Returns:
+        Union[AuthenticationConfiguration, None]: Authentication Configuration or None.
+    """
+    try:
+        return AuthenticationConfiguration.model_validate(config_data)
     except ValidationError:
         return None

--- a/video_streamer/core/streamer.py
+++ b/video_streamer/core/streamer.py
@@ -28,7 +28,7 @@ class Streamer:
         elif self._config.input_uri == "videotest":
             return VideoTestCamera("TANGO_URI", self._expt, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("http"):
-            return MJPEGCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
+            return MJPEGCamera(self._config.input_uri, self._expt, self._config.auth_config, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("redis"):
             return RedisCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel, self._config.in_redis_channel)
         
@@ -100,8 +100,8 @@ class FFMPGStreamer(Streamer):
         :returns: Processes performing encoding
         :rtype: tuple
         """
-        source_size = "%s:%s" % source_size
-        out_size = "%s:%s" % out_size
+        source_size_str = "%s:%s" % source_size
+        out_size_str = "%s:%s" % out_size
 
         ffmpeg_args = [
             "ffmpeg",
@@ -110,7 +110,7 @@ class FFMPGStreamer(Streamer):
             "-pixel_format",
             "rgb24",
             "-s",
-            source_size,
+            source_size_str,
             "-i",
             "-",
             "-f",
@@ -118,7 +118,7 @@ class FFMPGStreamer(Streamer):
             "-q:v",
             "%s" % quality,
             "-vf",
-            "scale=%s" % out_size,
+            "scale=%s" % out_size_str,
             "-vcodec",
             "mpeg1video",
             "http://127.0.0.1:%s/video_input/" % port,

--- a/video_streamer/main.py
+++ b/video_streamer/main.py
@@ -2,7 +2,7 @@ import uvicorn
 import argparse
 
 from video_streamer.server import create_app
-from video_streamer.core.config import get_config_from_dict, get_config_from_file
+from video_streamer.core.config import get_config_from_dict, get_config_from_file, get_auth_config_from_dict
 
 
 def parse_args() -> argparse.Namespace:
@@ -124,6 +124,30 @@ def parse_args() -> argparse.Namespace:
         default="CameraStream",
     )
 
+    opt_parser.add_argument(
+        "-auth",
+        "--auth_type",
+        dest="auth_type",
+        help="Type of authentication request",
+        default="Digest",
+    )
+
+    opt_parser.add_argument(
+        "-user",
+        "--username",
+        dest="username",
+        help="Username for authentication request",
+        default="",
+    )
+
+    opt_parser.add_argument(
+        "-pass",
+        "--password",
+        dest="password",
+        help="Password for authentication request",
+        default="",
+    )
+
     return opt_parser.parse_args()
 
 
@@ -151,6 +175,11 @@ def run() -> None:
                     "hash": args.hash,
                     "size": _size,
                     "in_redis_channel": args.in_redis_channel,
+                    "auth_config": get_auth_config_from_dict({
+                        "type": args.auth_type,
+                        "username": args.username,
+                        "password": args.password
+                    })
                 }
             }
         }


### PR DESCRIPTION
This PR updates the MJPEG camera by introducing some improvements to its general usage:

- The image data will be send to the streamer in form of a raw `rgb24` image, similar to how the data is stored for the other cameras and equal to the expected format for the `ffmpeg` (MPEG1) streamer. It involves the drop of the specific `get_jpeg` function from this class, it now uses the same as the parent class. This would introduce two additional transformation operation when the `MJPEG` streamer is used, however using the MJPEG streamer with the MJPEG Camera might already be unnecessary.
- Using a bytearray object instead of a bytes object for the buffer to save some memory allocation overheat
- The images in the stream are detected and saved to data based on the boundary defined in the response header compared to the previously `StreamConsumedError` (which is not present on every stream)
- Added a request exception handler to exit the while loop if there would be an unexpected exception from the request. 
- Integrated Authentication on remote streams through set flags in the command line execution (Currently available are Digest and Basic authentication)

Where possible, this PR also enforces to use the correct types by using casting and correct type hints in the whole codebase