### PR TITLE
change authentication default to None

### DIFF
--- a/video_streamer/main.py
+++ b/video_streamer/main.py
@@ -138,7 +138,7 @@ def parse_args() -> argparse.Namespace:
         "--auth_type",
         dest="auth_type",
         help="Type of authentication request",
-        default="Digest",
+        default=None,
     )
 
     opt_parser.add_argument(


### PR DESCRIPTION
This PR sets the default for Authentication for `MJPEG` streams to `None`