### PR TITLE
update doc and fix typo

### DIFF
--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -23,8 +23,9 @@ options:
                                             connections default (0.0.0.0)
   -p PORT, --port PORT                      Port
   -q QUALITY, --quality                     QUALITY
-                                            Compresion rate/quality
+                                            Compression rate/quality
   -s SIZE, --size SIZE                      size
+  -vf, --vflip                              Flip video vertically, default False
   -of OUTPUT_FORMAT, --output-format        OUTPUT_FORMAT
                                             output format, MPEG1 or MJPEG
   -id HASH, --id HASH                       Stream id

--- a/video_streamer/main.py
+++ b/video_streamer/main.py
@@ -46,7 +46,7 @@ def parse_args() -> argparse.Namespace:
         "-q",
         "--quality",
         dest="quality",
-        help="Compresion rate/quality",
+        help="Compression rate/quality",
         default=4,
     )
 


### PR DESCRIPTION
This PR adds a line for the new functionality of vertical flipping added in #30 to the documentation.
Additionally, this fixes a typo in the parameter description.