### PR TITLE
fixing handlers in lifespan

### DIFF
--- a/video_streamer/main.py
+++ b/video_streamer/main.py
@@ -1,15 +1,9 @@
 import uvicorn
 import argparse
-import sys
-import signal
 
 from video_streamer.server import create_app
 from video_streamer.core.config import get_config_from_dict, get_config_from_file, get_auth_config_from_dict
 
-
-def handle_sigterm(signal, frame):
-    print("Received SIGTERM, shutting down gracefully...")
-    sys.exit(0)  # Exit the program with a clean status
 
 def parse_args() -> argparse.Namespace:
     opt_parser = argparse.ArgumentParser(description="mxcube video streamer")
@@ -219,10 +213,9 @@ def run() -> None:
                 reload=False,
                 workers=1,
                 log_level=loglevel,
+                lifespan="on",
             )
 
-            signal.signal(signal.SIGTERM, handle_sigterm)
-            signal.signal(signal.SIGINT, handle_sigterm)
             server = uvicorn.Server(config=config)
             server.run()
 


### PR DESCRIPTION
This PR moves the initialization of the signal handlers into lifespan. This helps with `uvicorn` not interfering with the handlers execution. The handlers behave as follows: on `SIGINT` or `SIGTERM` an exit is triggered, which in return triggers the end of the lifespan (part after yield in code). This part then calls the stop of the streaming processes.

It also changes the `stop` function of the Streamer classes to firstly terminate the processes graceful (allowing resource clearing), waiting for a short amount of time and kill the processes forcefully if they haven't finished.

While at it, I also modified the type hints of the streamers start function to actually be the types they return instead of `None`