### PR TITLE
updating jinja2 version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -328,14 +328,14 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]
@@ -1475,4 +1475,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "147460c61af1a757e539dff685af7b44873f0cd3b72ca1b4431a76540c47f250"
+content-hash = "57dad1bf50d0007bcfa0781c5ba0a6c3b58412146117ba191504e7932f7e54eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ fastapi = "^0.115.6"
 pillow = "^10.4.0"
 uvicorn = "^0.34.0"
 pytango = {version = "^9.3.6", optional = true}
-jinja2 = "^3.1.5"
+jinja2 = "^3.1.6"
 websockets = "^12.0"
 redis = ">=4.3.5,<5.0.0"
 opencv-python = "^4.10.0.84"


### PR DESCRIPTION
This PR bumps the version of jinja2 to 3.1.6 to patch a security vulnerability discovered in a previous version