### PR TITLE
Boundary issue with MJPEG input streams

### DIFF
--- a/video_streamer/core/camera.py
+++ b/video_streamer/core/camera.py
@@ -147,7 +147,8 @@ class MJPEGCamera(Camera):
         Extract a single JPEG frame from the buffer if a complete frame exists.
         Returns a tuple of (frame_data, remaining_buffer).
         """
-        boundary_bytes = f"--{boundary}".encode()
+        boundary_body_prefix = "--" if not boundary.startswith("--") else ""
+        boundary_bytes = f"{boundary_body_prefix}{boundary}".encode()
         start_index = buffer.find(boundary_bytes)
         if start_index == -1:
             return None, buffer  # Boundary not found


### PR DESCRIPTION
According to [RFC2046 Section5.1.1](https://www.tech-invite.com/y20/tinv-ietf-rfc-2046.html#e-5-1-1) the delimiter of a multipart message should start with two hyphens ('--').

 In our case, we run into a problem, where the header response from our input stream explicitly named the two hyphens as part of the boundary. This broke the decryption of the images, as the video-streamer automatically added two additional hyphens to the boundary found in the header, resulting a delimiter starting with 4 hyphens.

To fix this, this PR adds a check to prevent the addition of "unnecessary" characters, if the hyphens are already in the header.