### PR TITLE
Add EPICS PVA support to camera.

### DIFF
--- a/docs/usage/cameras.md
+++ b/docs/usage/cameras.md
@@ -10,6 +10,7 @@ The streamer automatically selects the appropriate mode for the camera based on 
 |MJPEGCamera|Should start with `http://` and include host and port, e.g. `http://localhost:8000`|
 |RedisCamera|Should start with `redis://` and include host and port of redis server, e.g. `redis://localhost:6379`|
 |LimaCamera|URI of the Tango (Lima) device|
+|EpicsPVACamera|Should start with `pva://` and include the image PV name, e.g. `pva://SIM:Pva1:Image`|
 ---
 
 ## TestCamera
@@ -35,6 +36,14 @@ The `LimaCamera` supports streaming from a Tango (Lima) device. by polling the i
 The `MJPEGCamera` provides specialized support for *MJPEG* video streams. It is designed to fetch images from an *MJPEG* stream, such as those from a web camera or a streaming url.
 
 > **Note**: Currently the `MJPEGCamera` is the only camera that does not support conversion to a `Redis` Pub/Sub channel (more about streaming on a [redis channel](setup.md#dual-streaming-seamlessly-serve-mjpeg-and-redis-pubsub-video-feeds))
+
+---
+
+## EpicsPVACamera
+
+The `EpicsPVACamera` supports streaming from Epics areaDetector servers with PVA enabled. It uses the `p4p` library to pool the image from the IOC and parse its content using the `NTNDArray.unwrap` method.
+
+> **Note**: Currently, only 3 dimensional (RGB) uncompressed images are supported. In the future, when `p4p` implements decompression, this can be changed.
 
 #### Authentication for MJPEG Streams
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pydantic = ">=2.8.2,<2.9.0"
 pydantic-core = "2.20.1"
 pydantic-settings = ">=2.4.0"
 pytango = {version = "^9.3.6", optional = true}
+p4p = {version = "^4.2.2", optional = true}
 redis = ">=4.3.5,<5.0.0"
 requests = "^2.32.4"
 typing-extensions = "^4.14.1"
@@ -47,6 +48,7 @@ pytest-cov = "5.0.0"
 
 [tool.poetry.extras]
 tango = ["pytango"]
+epics = ["p4p"]
 
 [tool.black]
 line-length = 88

--- a/video_streamer/core/camera.py
+++ b/video_streamer/core/camera.py
@@ -317,6 +317,87 @@ class LimaCamera(Camera):
         time.sleep(self._sleep_time / 2)
 
 
+class EpicsPVACamera(Camera):
+    def __init__(self, device_uri: str, sleep_time: float, debug: bool = False,
+                 redis: str = None, redis_channel: str = None):
+        super().__init__(device_uri, sleep_time, debug, redis, redis_channel)
+
+        try:
+            import p4p.client.thread
+            import p4p.nt
+            self._p4p = p4p
+        except ImportError:
+            logging.error("P4P is not installed.")
+            raise ImportError("P4P is not installed. ")
+
+        self._context = self._get_context()
+        self._pv_name = self._device_uri.removeprefix("pva://")
+        _, self._height, self._width, _ = self._get_image(self._pv_name)
+
+        # EPICS uses a worker thread. As the streamer classes launches a forked
+        # `poll_image` proccess with `multiprocessing` to serve the image, the
+        # reference to the context is lost. In order to work around this
+        # situation we need to ensure the context is deleted and then recreate
+        # it after the fork - e.g. in poll_image
+        self._context.disconnect()
+        del self._context
+        self._context = None
+
+    def _get_context(self):
+        try:
+            ctx = self._p4p.client.thread.Context('pva', nt=False)
+            logging.info("Connecting to pva context")
+        except Exception:
+            logging.exception("")
+            logging.info("Could not connect to pva context...")
+            sys.exit(-1)
+        else:
+            return ctx
+
+    def _get_image(self, pv_name: str):
+        data = self._context.get(pv_name)
+
+        # Checking if it is a 3 dimensional image and if the codec is empty -
+        # i.e. the image is uncompressed
+        if (len(data.dimension) == 3 and data.dimension[0].size == 3 and data.codec.name == ""):
+            array_data = self._p4p.nt.NTNDArray.unwrap(data)
+            im = Image.fromarray(array_data)
+            raw_data = im.convert("RGB").tobytes()
+            return raw_data, array_data.shape[0], array_data.shape[1], data
+        else:
+            raise ValueError(
+                "Only uncompressed RGB images are supported, for now")
+
+    def _poll_once(self) -> None:
+        if self._context is None:
+            self._context = self._get_context()
+
+        raw_data, height, width, nt_data = self._get_image(self._pv_name)
+
+        if width != self._width or height != self._height:
+            raise ValueError(
+                f'Image dimensions have changed. \
+                 \n Expected: ({self._width}, {self._height}) \
+                 \n Received: ({width}, {height})')
+
+        self._write_data(bytearray(raw_data))
+
+        timestamp = nt_data.dataTimeStamp.secondsPastEpoch
+        timestamp += nt_data.dataTimeStamp.nanoseconds * 10**-9
+
+        if self._redis:
+            frame_dict = {
+                "data": base64.b64encode(raw_data).decode('utf-8'),
+                "size": (width, height),
+                "time": datetime.fromtimestamp(timestamp).strftime("%H:%M:%S.%f"),
+                "frame_number": nt_data.id,
+            }
+            self._redis_client.publish(
+                self._redis_channel, json.dumps(frame_dict))
+
+        time.sleep(self._sleep_time)
+
+
 class RedisCamera(Camera):
     def __init__(self, device_uri: str, sleep_time: float, debug: bool = False, out_redis: str = None, out_redis_channel: str = None, in_redis_channel: str = 'frames'):
         super().__init__(device_uri, sleep_time, debug, out_redis, out_redis_channel)

--- a/video_streamer/core/streamer.py
+++ b/video_streamer/core/streamer.py
@@ -4,7 +4,7 @@ import queue
 import time
 from typing import Tuple, Generator, Any, Union
 
-from video_streamer.core.camera import TestCamera, LimaCamera, MJPEGCamera, VideoTestCamera, Camera, RedisCamera
+from video_streamer.core.camera import TestCamera, LimaCamera, MJPEGCamera, VideoTestCamera, Camera, RedisCamera, EpicsPVACamera
 from video_streamer.core.config import SourceConfiguration
 
 
@@ -31,7 +31,10 @@ class Streamer:
             return MJPEGCamera(self._config.input_uri, self._expt, self._config.auth_config, False, self._config.redis, self._config.redis_channel)
         elif self._config.input_uri.startswith("redis"):
             return RedisCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel, self._config.in_redis_channel)
-        
+        elif self._config.input_uri.startswith("pva"):
+            return EpicsPVACamera(self._config.input_uri, self._expt, False,
+                                  self._config.redis, self._config.redis_channel)
+
         return LimaCamera(self._config.input_uri, self._expt, False, self._config.redis, self._config.redis_channel)
 
 


### PR DESCRIPTION
Using PVA here has the advantage of receiving all the image metadata in a single PV - i.e. a single "connection" to the device - with guaranteed atomic updates.

Since EPICS uses a dedicated worker thread, as we fork before serving the image in poll_image, the reference to the context is lost. In order to work around this situation we need to ensure the context is deleted and then recreate it after the fork - e.g. in poll_image.

For now, only RGB images are supported. The performed conversions and redis integration are based on TestCamera class.

Also, we don't support compressed images. This can be changed when p4p unwrappers implement the uncompress feature.