### PR TITLE
Use containerization scheme.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build image
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    env:
+      TAG: ${{ github.event_name == 'push' && github.ref_name || github.head_ref }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to registry
+        if: github.event_name == 'push' && vars.PUSH_TO_REGISTRY == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push tagged image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt install -y --no-install-recommends ffmpeg libsm6 libxext6
+
+RUN pip install mxcube-video-streamer[tango]
+RUN pip install mxcube-video-streamer[epics]
+
+ENTRYPOINT ["video-streamer"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  video-streamer:
+    image: ghcr.io/mxcube/video-streamer
+    network_mode: host
+    volumes:
+      - ./example_config.json:/config.json
+    command: -c /config.json -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   video-streamer:
-    image: ghcr.io/mxcube/video-streamer
+    image: ghcr.io/mxcube/video-streamer:${TAG}
     network_mode: host
     volumes:
       - ./example_config.json:/config.json


### PR DESCRIPTION
Built the video-streamer application with support to both epics and
tango optional dependencies. Also mounts the example_config.json file to
be used when launching the application.

By setting network=host, we don't need to be explicit about port
mapping. It is also necessary for receiving the PV when connecting to
EPICS servers.