### PR TITLE
add tags to docker push event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }}


### PR DESCRIPTION
While the workflow for Docker builds the Docker images correctly and logs in to the registry. The final step for a push to the registry when pushing to a new tag on GitHub failed. (see [failed workflow](https://github.com/mxcube/video-streamer/actions/runs/28505073891))

The reason was the missing tags field for the push, i.e., the workflow did not know where to push to. This PR intends to fix this by adding tags