### PR TITLE
update toml to follow PEP 621

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2767,4 +2767,4 @@ tango = ["pytango"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "3f40d7571aee56560dabb967dd0d1546c83eb3cb2f82b40dfa9f229930309078"
+content-hash = "38cd17f7558a4189a943078ab54e44edd31cd9ab2b56d2e420685e387c4ce741"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
-[tool.poetry]
+[project]
 name = "mxcube_video_streamer"
 version = "1.9.1"
-packages = [{include = "video_streamer"}]
-license = "MIT"
 description = "FastAPI Based video streamer"
-authors = ["Marcus Oskarsson <oscarsso@esrf.fr>"]
-maintainers = [
-    "Marcus Oskarsson <oscarsso@esrf.fr>",
+authors = [
+    { name = "Marcus Oskarsson", email = "oscarsso@esrf.fr" },
 ]
+maintainers = [
+    { name = "Marcus Oskarsson", email = "oscarsso@esrf.fr" },
+    { name = "Yan Walesch", email = "yan.walesch@esrf.fr"}
+]
+license = "MIT"
 readme = "README.md"
-homepage = "http://github.com/mxcube/video-streamer"
-repository = "http://github.com/mxcube/video-streamer"
-documentation = "https://mxcube.github.io/video-streamer/"
+requires-python = ">=3.11,<3.14"
 keywords = ["mxcube", "fast-api-streamer", "video_streamer", "mxcubeweb"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -21,26 +21,37 @@ classifiers = [
     "Natural Language :: English",
     "Topic :: Scientific/Engineering",
 ]
+dependencies = [
+    "fastapi[standard-no-fastapi-cloud-cli]>=0.138.0,<0.139.0",
+    "numpy>=1.26.0,<2.0",
+    "opencv-python>=4.10.0.84,<5.0.0.0",
+    "pillow>=12.3.0,<13.0.0",
+    "pydantic>=2.13,<3.0",
+    "pydantic-core>=2.46,<3.0",
+    "pydantic-settings>=2.4.0",
+    "redis>=4.3.5,<5.0.0",
+    "requests>=2.33.1,<3.0.0",
+    "typing-extensions>=4.14.1,<5.0.0",
+    "uvicorn[standard]>=0.34.0,<0.35.0",
+    "aiortc>=1.14.0,<2.0.0",
+    "asyncio>=4.0.0,<5.0.0",
+    "av>=16,<17",
+]
 
-[tool.poetry.dependencies]
-python = ">=3.11,<3.14"
-fastapi = { version = "^0.138.0", extras = ["standard-no-fastapi-cloud-cli"] }
-numpy = ">=1.26.0,<2.0"
-opencv-python = "^4.10.0.84"
-pillow = "^12.3.0"
-pydantic = "^2.13"
-pydantic-core = "2.46"
-pydantic-settings = ">=2.4.0"
-pytango = {version = "^9.3.6", optional = true}
-p4p = {version = "^4.2.2", optional = true}
-redis = ">=4.3.5,<5.0.0"
-requests = "^2.33.1"
-typing-extensions = "^4.14.1"
-uvicorn = { version = "^0.34.0", extras = ["standard"] }
-aiortc = "^1.14.0"
-asyncio = "^4.0.0"
-av = "^16"
+[project.optional-dependencies]
+tango = ["pytango>=9.3.6,<10.0.0"]
+epics = ["p4p>=4.2.2,<5.0.0"]
 
+[project.urls]
+Homepage = "http://github.com/mxcube/video-streamer"
+Repository = "http://github.com/mxcube/video-streamer"
+Documentation = "https://mxcube.github.io/video-streamer/"
+
+[project.scripts]
+video-streamer = "video_streamer.main:run"
+
+[tool.poetry]
+packages = [{include = "video_streamer"}]
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.6.1"
@@ -48,10 +59,6 @@ mkdocs-macros-plugin = "^1.3.7"
 pre-commit = "3.5.0"
 pytest = "^9.0.3"
 pytest-cov = "5.0.0"
-
-[tool.poetry.extras]
-tango = ["pytango"]
-epics = ["p4p"]
 
 [tool.black]
 line-length = 88
@@ -88,8 +95,5 @@ quote-style = "double"
 indent-style = "space"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.scripts]
-video-streamer = 'video_streamer.main:run'


### PR DESCRIPTION
This PR updates `pyproject.toml` to follow [PEP 621](https://peps.python.org/pep-0621/). This allows it to be read by any IDE and most installers. This includes the metadata and extras to be correctly read by any installer, not only Poetry